### PR TITLE
Fix rain reporting by using precipLastHour instead of precipRate

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1120,7 +1120,7 @@ function updateWunderground_() {
   if (conditions.humidity != null) request += '&humidity=' + conditions.humidity;
   if (conditions.uv != null) request += '&uv=' + conditions.uv;
   if (conditions.solarRadiation != null) request += '&solarradiation=' + conditions.solarRadiation;
-  if (conditions.precipRate != null) request += '&rainin=' + conditions.precipRate.in;
+  if (conditions.precipLastHour != null) request += '&rainin=' + conditions.precipLastHour.in;
   if (conditions.precipSinceMidnight != null) request += '&dailyrainin=' + conditions.precipSinceMidnight.in;
   request += '&softwaretype=appsscriptforwarder' + version + '&action=updateraw&realtime=1&rtfreq=60';
 
@@ -1178,7 +1178,7 @@ function updatePWSWeather_() {
   if (conditions.humidity != null) request += '&humidity=' + conditions.humidity;
   if (conditions.uv != null) request += '&uv=' + conditions.uv;
   if (conditions.solarRadiation != null) request += '&solarradiation=' + conditions.solarRadiation;
-  if (conditions.precipRate != null) request += '&rainin=' + conditions.precipRate.in;
+  if (conditions.precipLastHour != null) request += '&rainin=' + conditions.precipLastHour.in;
   if (conditions.precipSinceMidnight != null) request += '&dailyrainin=' + conditions.precipSinceMidnight.in;
   request += '&softwaretype=appsscriptforwarder&action=updateraw';
   
@@ -1338,7 +1338,7 @@ function updateWOW_() {
   if (conditions.winddir != null) request += '&winddir=' + conditions.winddir;
   if (conditions.pressure != null) request += '&baromin=' + conditions.pressure.inHg;
   if (conditions.humidity != null) request += '&humidity=' + conditions.humidity;
-  if (conditions.precipRate != null) request += '&rainin=' + conditions.precipRate.in;
+  if (conditions.precipLastHour != null) request += '&rainin=' + conditions.precipLastHour.in;
   if (conditions.precipSinceMidnight != null) request += '&dailyrainin=' + conditions.precipSinceMidnight.in;
   request += '&softwaretype=appsscriptforwarder' + version;
 
@@ -1378,7 +1378,7 @@ function updateCWOP_() {
   if (conditions.pressure != null) request += '&baromin=' + conditions.pressure.hPa;
   if (conditions.humidity != null) request += '&humidity=' + conditions.humidity;
   if (conditions.solarRadiation != null) request += '&solarradiation=' + conditions.solarRadiation;
-  if (conditions.precipRate != null) request += '&rainin=' + conditions.precipRate.in;
+  if (conditions.precipLastHour != null) request += '&rainin=' + conditions.precipLastHour.in;
   if (conditions.precipSinceMidnight != null) request += '&dailyrainin=' + conditions.precipSinceMidnight.in;
   if (conditions.precipLast24Hours != null) request += '&last24hrrainin=' + conditions.precipLast24Hours.in;
   request += '&software=appsscriptforwarder' + version;


### PR DESCRIPTION
## Summary
- Corrects rain reporting by replacing `precipRate` with `precipLastHour` for rain measurements
- Ensures accurate rain data is sent in requests to Wunderground and other services

## Changes

### Code Updates
- Updated `updateWunderground_`, `updatePWSWeather_`, `updateWOW_`, and `updateCWOP_` functions
- Replaced all instances of `conditions.precipRate` with `conditions.precipLastHour` for the `rainin` parameter

## Test plan
- Verified that rain data is correctly reported using the last hour precipitation value
- Confirmed no regressions in other weather data reporting
- Tested integration with Wunderground and related endpoints to ensure proper data forwarding

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/71e67a00-95f5-409c-923f-7e22fe7c3bff