### PR TITLE
Add Temperatur.nu forwarding support (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,16 +219,16 @@ and periodically sends it on to
   Start by [registering a new "Reporting URL/Hashcode" station](https://www.temperatur.nu/nystation/). Then:
 
   - Set `updateTemperaturNu` to `true` on Line 76
-  - Set `temperaturNuHash` to your API Key on Line 77
+  - Set `temperaturNuHash` to your Hash Code on Line 77
   </details>
   <details>
     <summary>NOAA Citizen Weather Observer Program (CWOP)</summary>
 
   Send to [CWOP](https://madis.ncep.noaa.gov/madis_cwop.shtml). Start by [registering for a new station](https://madis.ncep.noaa.gov/madis_cwop.shtml), then when you receive your email:
 
-  - Set `updateCWOP` to `true` on Line 76
-  - Set `cwopStationIDOrHamCallsign` to your assigned CWOP station ID that you received via email on Line 77
-  - If you are using your ham radio callsign as your station ID and you have received a validation code from NOAA CWOP support, set `cwopValidationCode` to your validation code on Line 78
+  - Set `updateCWOP` to `true` on Line 79
+  - Set `cwopStationIDOrHamCallsign` to your assigned CWOP station ID that you received via email on Line 80
+  - If you are using your ham radio callsign as your station ID and you have received a validation code from NOAA CWOP support, set `cwopValidationCode` to your validation code on Line 81
   </details>
 
 4. Run the "Schedule" function (not the "doPost" function) by selecting "Schedule" in the dropdown and pressing the `▷ Run` button in the toolbar. You're done! You can see it periodically running in the `☰▶` Executions tab on the left sidebar. This code is executed on Google's servers and does not require a computer to remain on.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ and periodically sends it on to
 - [WeatherCloud](https://weathercloud.com/),
 - [OpenWeatherMap](https://openweathermap.org/stations),
 - [WindGuru](https://www.windguru.cz/map/station/),
-- [WOW-BE Reboot (RMI)](https://wow.meteo.be/) and/or
+- [WOW-BE Reboot (RMI)](https://wow.meteo.be/),
+- [Temperatur.nu](https://www.temperatur.nu/) and/or
 - [NOAA CWOP](https://madis.ncep.noaa.gov/madis_cwop.shtml).
 
 ## Setup
@@ -209,6 +210,16 @@ and periodically sends it on to
   - Set `wowBEAuthKey` to your chosen 6-Digit Authentication Key (PIN) on Line 74
 
   Note: WOW-BE Reboot replaces MET UK WOW, which is retiring in 2026. If you previously used MET UK WOW, you will need to re-register your station on WOW-BE as existing station IDs are not transferable.
+  </details>
+  <details>
+    <summary>Temperatur.nu</summary>
+
+  Send to [Temperatur.nu](https://www.temperatur.nu/):
+
+  Start by [registering a new "Reporting URL/Hashcode" station](https://www.temperatur.nu/nystation/). Then:
+
+  - Set `updateTemperaturNu` to `true` on Line 76
+  - Set `temperaturNuHash` to your API Key on Line 77
   </details>
   <details>
     <summary>NOAA Citizen Weather Observer Program (CWOP)</summary>

--- a/code.gs
+++ b/code.gs
@@ -1486,7 +1486,7 @@ function updateTemperaturNu_() {
   let conditions = JSON.parse(CacheService.getScriptCache().get('conditions'));
 
   if (conditions.temp == null) {
-    throw 'Temperatur.nu requires temp. Please ensure your station has those sensors. For more information, visit: https://www.temperatur.nu/info/rapportera-till-temperatur-nu/';
+    throw 'Temperatur.nu requires temp. Please ensure your station has that sensor. For more information, visit: https://www.temperatur.nu/info/rapportera-till-temperatur-nu/';
   };
 
   let request = 'https://www.temperatur.nu/rapportera.php';

--- a/code.gs
+++ b/code.gs
@@ -73,6 +73,9 @@ const updateWOWBE = false;
 const wowBESiteID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 const wowBEAuthKey = 'xxxxxx';
 ///
+const updateTemperaturNu = false;
+const temperaturNuHash = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+///
 const updateCWOP = false;
 const cwopStationIDOrHamCallsign = 'CW0001';
 const cwopValidationCode = null;
@@ -140,6 +143,7 @@ function Schedule() {
   if (updateOpenWeatherMap) ScriptApp.newTrigger('updateOpenWeatherMap_').timeBased().everyMinutes(1).create();
   if (updateWindGuru) ScriptApp.newTrigger('updateWindGuru_').timeBased().everyMinutes(1).create();
   if (updateWOWBE) ScriptApp.newTrigger('updateWOWBE_').timeBased().everyMinutes(5).create();
+  if (updateTemperaturNu) ScriptApp.newTrigger('updateTemperaturNu_').timeBased().everyMinutes(1).create();
   if (updateCWOP) ScriptApp.newTrigger('updateCWOP_').timeBased().everyMinutes(5).create();
   console.log('Scheduled! Check Executions ☰▶ tab for status.');
   checkGithubReleaseVersion_();
@@ -1466,6 +1470,28 @@ function updateWOWBE_() {
   if (conditions.precipRate != null) request += '&rainin=' + conditions.precipRate.in;
   if (conditions.precipSinceMidnight != null) request += '&dailyrainin=' + conditions.precipSinceMidnight.in;
   request += '&softwaretype=appsscriptforwarder' + version;
+
+  let response = UrlFetchApp.fetch(request).getContentText();
+
+  console.log(response);
+
+  return response;
+
+}
+
+// Temperatur.nu only requires temperature in Celsius
+// https://www.temperatur.nu/info/rapportera-till-temperatur-nu/
+function updateTemperaturNu_() {
+
+  let conditions = JSON.parse(CacheService.getScriptCache().get('conditions'));
+
+  if (conditions.temp == null) {
+    throw 'Temperatur.nu requires temp. Please ensure your station has those sensors. For more information, visit: https://www.temperatur.nu/info/rapportera-till-temperatur-nu/';
+  };
+
+  let request = 'https://www.temperatur.nu/rapportera.php';
+  request += '?hash=' + temperaturNuHash;
+  request += '&t=' + conditions.temp.c;
 
   let response = UrlFetchApp.fetch(request).getContentText();
 


### PR DESCRIPTION
## Description
Adds support for Temperatur.nu weather station forwarding, Closes #64.

## Changes
- Added `updateTemperaturNu` configuration flag
- Added `temperaturNuHash` for API authentication
- Implemented `updateTemperaturNu_()` function
- Updated README.md with Temperatur.nu setup instructions
- Follows existing 1-minute update interval pattern

## Testing
Users can enable by setting:
- `updateTemperaturNu = true`
- `temperaturNuHash = '[their station hash]'`

Data is sent to: https://www.temperatur.nu/rapportera.php